### PR TITLE
Don't prepend an underscore to the field name.

### DIFF
--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -7,7 +7,7 @@ module Mongoid
     module ClassMethods
 
       def enum(name, values, options = {})
-        field_name = :"_#{name}"
+        field_name = name.to_sym
         options = default_options(values).merge(options)
 
         set_values_constant name, values


### PR DESCRIPTION
Since there doesn't seem to be a good reason to have an underscore in front of the field name, I've removed it.  This makes it much easier to convert existing "string" fields to be an enum (i.e. no migrations required)

Do you know of any problems this would cause?

I'd love to get this merged into the main gem. Are you interested in supporting this? 

Since it is not backwards compatible, would we want to make this a configuration setting?  