### PR TITLE
Add mappings feature as rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Payment::STATUS
 # => [:pending, :approved, :declined]
 ```
 
+## Mappings
+
+In rare circumstances you might need to access the mapping directly. The mappings are exposed through a class method with the pluralized attribute name:
+
+Payment.statuses # => { "pending" => 0, "approved" => 1, "declined" =>2 }
+Use that class method when you need to know the ordinal value of an enum:
+
+Payment.where("status <> ?", Payment.statuses[:approved])
+Where conditions on an enum attribute must use the ordinal value of an enum.
+
 
 ## Validations
 

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -1,5 +1,6 @@
 require "mongoid/enum/version"
 require "mongoid/enum/validators/multiple_validator"
+require 'active_support/inflector'
 
 module Mongoid
   module Enum
@@ -11,6 +12,7 @@ module Mongoid
         options = default_options(values).merge(options)
 
         set_values_constant name, values
+        set_values_mapping name,values
 
         create_field field_name, options
         alias_attribute name, field_name
@@ -32,6 +34,10 @@ module Mongoid
       def set_values_constant(name, values)
         const_name = name.to_s.upcase
         const_set const_name, values
+      end
+
+      def set_values_mapping(name, values)
+        class_eval "def self.#{name.to_s.pluralize}() @_enum_mappings = {}.tap {|hash| #{values}.each_with_index {|item, index| hash[item] = index}} end"
       end
 
       def create_field(field_name, options)

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "mongoid", "~> 4.0"
+  spec.add_runtime_dependency 'activesupport', '~> 4.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/mongoid/enum/validators/multiple_validator_spec.rb
+++ b/spec/mongoid/enum/validators/multiple_validator_spec.rb
@@ -16,14 +16,14 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       context "and value is nil" do
         before(:each) { validator.validate_each(record, attribute, nil) }
         it "validates" do
-          expect(record.errors[attribute].empty?).to be_true
+          expect(record.errors[attribute].empty?).to be_truthy
         end
       end
 
       context "and value is []" do
         before(:each) { validator.validate_each(record, attribute, []) }
         it "validates" do
-          expect(record.errors[attribute].empty?).to be_true
+          expect(record.errors[attribute].empty?).to be_truthy
         end
       end
     end
@@ -32,14 +32,14 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       context "and value is nil" do
         before(:each) { validator.validate_each(record, attribute, nil) }
         it "won't validate" do
-          expect(record.errors[attribute].any?).to be_true
+          expect(record.errors[attribute].any?).to be_truthy
           expect(record.errors[attribute]).to eq ["is not in #{values.join ", "}"]
         end
       end
       context "and value is []" do
         before(:each) { validator.validate_each(record, attribute, []) }
         it "won't validate" do
-          expect(record.errors[attribute].any?).to be_true
+          expect(record.errors[attribute].any?).to be_truthy
           expect(record.errors[attribute]).to eq ["is not in #{values.join ", "}"]
         end
       end
@@ -49,7 +49,7 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       let(:allow_nil) { rand(2).zero? }
       before(:each) { validator.validate_each(record, attribute, [values.sample]) }
       it "validates" do
-        expect(record.errors[attribute].empty?).to be_true
+        expect(record.errors[attribute].empty?).to be_truthy
       end
     end
 
@@ -57,7 +57,7 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       let(:allow_nil) { rand(2).zero? }
       before(:each) { validator.validate_each(record, attribute, [:amet]) }
       it "won't validate" do
-        expect(record.errors[attribute].any?).to be_true
+        expect(record.errors[attribute].any?).to be_truthy
       end
     end
 
@@ -65,7 +65,7 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       let(:allow_nil) { rand(2).zero? }
       before(:each) { validator.validate_each(record, attribute, [values.first, values.last]) }
       it "validates" do
-        expect(record.errors[attribute].empty?).to be_true
+        expect(record.errors[attribute].empty?).to be_truthy
       end
     end
 
@@ -73,7 +73,7 @@ describe Mongoid::Enum::Validators::MultipleValidator do
       let(:allow_nil) { rand(2).zero? }
       before(:each) { validator.validate_each(record, attribute, [values.first, values.last, :amet]) }
       it "won't validate" do
-        expect(record.errors[attribute].any?).to be_true
+        expect(record.errors[attribute].any?).to be_truthy
       end
     end
   end

--- a/spec/mongoid/enum_spec.rb
+++ b/spec/mongoid/enum_spec.rb
@@ -55,6 +55,16 @@ describe Mongoid::Enum do
       expect(klass::STATUS).to eq values
     end
   end
+  
+  describe "mapping" do
+    it "is should be returns mappings hash" do
+      expect(klass.statuses).to eq({awaiting_approval: 0, approved: 1, banned: 2})
+    end
+    
+    it "is should be returns mapping index 1" do
+      expect(klass.statuses[:approved]).to eq 1
+    end
+  end
 
   describe "accessors"do
     context "when singular" do
@@ -111,15 +121,15 @@ describe Mongoid::Enum do
             instance.save
             instance.author!
             instance.editor!
-            expect(instance.editor?).to be_true
-            expect(instance.author?).to be_true
+            expect(instance.editor?).to be_truthy
+            expect(instance.author?).to be_truthy
           end
         end
 
         context "when {{enum}} does not contain {{value}}" do
           it "returns false" do
             instance.save
-            expect(instance.author?).to be_false
+            expect(instance.author?).to be_falsey
           end
         end
       end


### PR DESCRIPTION
Add mappings feature as rails. The following document is from Rails Api: http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html

---

In rare circumstances you might need to access the mapping directly. The mappings are exposed through a class method with the pluralized attribute name:

``` ruby
Conversation.statuses # => { "active" => 0, "archived" => 1 }
```

Use that class method when you need to know the ordinal value of an enum:

``` ruby
Conversation.where("status <> ?", Conversation.statuses[:archived])
```

Where conditions on an enum attribute must use the ordinal value of an enum.

---
