### PR TITLE
Remove underscore from field name

### DIFF
--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -7,7 +7,7 @@ module Mongoid
     module ClassMethods
 
       def enum(name, values, options = {})
-        field_name = :"_#{name}"
+        field_name = name.to_sym
         options = default_options(values).merge(options)
 
         set_values_constant name, values

--- a/spec/mongoid/enum_spec.rb
+++ b/spec/mongoid/enum_spec.rb
@@ -12,9 +12,9 @@ describe Mongoid::Enum do
   let(:klass) { User }
   let(:instance) { User.new }
   let(:alias_name) { :status }
-  let(:field_name) { :"_#{alias_name}" }
+  let(:field_name) { :"#{alias_name}" }
   let(:values) { [:awaiting_approval, :approved, :banned] }
-  let(:multiple_field_name) { :"_roles" }
+  let(:multiple_field_name) { :"roles" }
 
   describe "field" do
     it "is defined" do


### PR DESCRIPTION
Since there doesn't seem to be a good reason to have an underscore in front of the field name, I've removed it. This makes it much easier to convert existing "string" fields to be an enum (i.e. no migrations required)

Do you know of any problems this would cause?

I'd love to get this merged into the main gem. Are you interested in supporting this?

Since it is not backwards compatible, would we want to make this a configuration setting?