### PR TITLE
Bump version to mongoid 5.0.0.beta

### DIFF
--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", ">= 4.0"
+  spec.add_runtime_dependency "mongoid", "~> 5.0.0.beta"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 4.0"
+  spec.add_runtime_dependency "mongoid", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Bump version to the last mongoid release 5.0.0.beta
