### PR TITLE
Update required major version of mongoid to 5

### DIFF
--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 4.0"
+  spec.add_runtime_dependency "mongoid", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec", "~> 4.6.2"
   spec.add_development_dependency "database_cleaner", "~> 1.2.0"
-  spec.add_development_dependency "mongoid-rspec", "~> 2.1.0"
+  spec.add_development_dependency "mongoid-rspec", "~> 3.0"
 end

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec", "~> 4.6.2"
-  spec.add_development_dependency "database_cleaner", "~> 1.2.0"
   spec.add_development_dependency "mongoid-rspec", "~> 3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,4 @@ RSpec.configure do |config|
 end
 
 Mongoid.load!(File.expand_path("../support/mongoid.yml", __FILE__), :test)
+Mongo::Logger.logger.level = ::Logger::INFO

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,15 @@
 $: << File.expand_path("../../lib", __FILE__)
 
-require 'database_cleaner'
 require 'mongoid'
-require 'mongoid-rspec'
+require "mongoid/rspec"
 require 'mongoid/enum'
 
 ENV['MONGOID_ENV'] = "test"
 
 RSpec.configure do |config|
   config.include Mongoid::Matchers
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
-  end
 
-  config.after(:each) do
-    DatabaseCleaner.clean
+  config.before(:each) do
     Mongoid.purge!
   end
 end

--- a/spec/support/mongoid.yml
+++ b/spec/support/mongoid.yml
@@ -1,5 +1,5 @@
 test:
-  sessions:
+  clients:
     default:
       database: mongoid-enum_test
       hosts:


### PR DESCRIPTION
@thetron Mongoid 5.0.0 is released: https://rubygems.org/gems/mongoid/versions/5.0.0

Hope you will merge this PR and publish new version of mongoid-enum to rubygems soon.
