### PR TITLE
convert :to_sym on read as well

### DIFF
--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -76,7 +76,7 @@ module Mongoid
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
+        class_eval "def #{name}() self.read_attribute(:#{field_name}).try(:to_sym) end"
       end
 
       def define_array_accessor(field_name, value)

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -71,7 +71,7 @@ module Mongoid
 
       def define_array_field_accessor(name, field_name)
         class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
+        class_eval "def #{name}() self.read_attribute(:#{field_name}).map{ |i| i.try(:to_sym) } end"
       end
 
       def define_string_field_accessor(name, field_name)


### PR DESCRIPTION
We have run into situations where the attr accessors return `String` instead of expected `Symbol`.

To enforce the expected behaviour I added explicit `to_sym` on the two dynamically generated getter methods.
