### PR TITLE
make sure getters always return Symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 script: "bundle exec rspec spec"
-
+sudo: false
 language: ruby
-
 rvm:
   - 1.9.3
   - 2.0.0
@@ -9,6 +8,5 @@ rvm:
   - 2.1.1
   - 2.1.2
   - jruby-19mode
-
 services:
   - mongodb

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -76,7 +76,7 @@ module Mongoid
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
+        class_eval "def #{name}() self.read_attribute(:#{field_name}).try(:to_sym) end"
       end
 
       def define_array_accessor(field_name, value)

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -71,7 +71,7 @@ module Mongoid
 
       def define_array_field_accessor(name, field_name)
         class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}) end"
+        class_eval "def #{name}() self.read_attribute(:#{field_name}).map{ |i| i.try(:to_sym) } end"
       end
 
       def define_string_field_accessor(name, field_name)

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -43,8 +43,7 @@ module Mongoid
       def create_validations(field_name, values, options)
         if options[:multiple] && options[:validate]
           validates field_name, :'mongoid/enum/validators/multiple' => { :in => values.map(&:to_sym), :allow_nil => !options[:required] }
-        #FIXME: Shouldn't this be `elsif options[:validate]` ???
-        elsif validate
+        elsif options[:validate]
           validates field_name, :inclusion => {:in => values.map(&:to_sym)}, :allow_nil => !options[:required]
         end
       end

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -15,7 +15,7 @@ module Mongoid
 
         create_field field_name, options
 
-        create_validations field_name, values, options
+        create_validations name, field_name, options
         define_value_scopes_and_accessors field_name, values, options
         define_field_accessor name, field_name, options
       end
@@ -40,11 +40,11 @@ module Mongoid
         field field_name, :type => type, :default => options[:default]
       end
 
-      def create_validations(field_name, values, options)
+      def create_validations(name, field_name, options)
         if options[:multiple] && options[:validate]
-          validates field_name, :'mongoid/enum/validators/multiple' => { :in => values.map(&:to_sym), :allow_nil => !options[:required] }
+          validates field_name, :'mongoid/enum/validators/multiple' => { :in => self.const_get(name.to_s.upcase), :allow_nil => !options[:required] }
         elsif options[:validate]
-          validates field_name, :inclusion => {:in => values.map(&:to_sym)}, :allow_nil => !options[:required]
+          validates field_name, :inclusion => {:in => self.const_get(name.to_s.upcase)}, :allow_nil => !options[:required]
         end
       end
 

--- a/lib/mongoid/enum.rb
+++ b/lib/mongoid/enum.rb
@@ -71,12 +71,12 @@ module Mongoid
 
       def define_array_field_accessor(name, field_name)
         class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}).map{ |i| i.try(:to_sym) } end"
+        class_eval "def #{name}() self.send(:#{field_name}).map{ |i| i.try(:to_sym) } end"
       end
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "def #{name}() self.read_attribute(:#{field_name}).try(:to_sym) end"
+        class_eval "def #{name}() self.send(:#{field_name}) end"
       end
 
       def define_array_accessor(field_name, value)

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 5"
+  spec.add_runtime_dependency "mongoid"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 5.0"
+  spec.add_runtime_dependency "mongoid", "~> 5"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
We have ran into several issues when relying on `enum` to return `Symbol` type.

This PR replaces `read_attribute` by `send`, since the `read_attribute` returns unprocessed (raw) value before typecast (`demongoize`) and therefore can potentially return something else than `Symbol`.

Also, this PR makes sure all Array values (in multiple option) are `Symbols` as well.

For your reference, here you can see how Mongoid uses `read_attribute` to get raw value which is then processed to a proper type using `demongoize`: https://github.com/mongodb/mongoid/blob/master/lib/mongoid/fields.rb#L411-L424

This is extermely important especially now, when `Symbols` are being deprecated and an app using Mongoid can potentially start returning `Strings` instead of `Symbols`. See here: https://jira.mongodb.org/browse/RUBY-1075?jql=project%20%3D%20RUBY%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20key%20DESC
