### PR TITLE
 Improve build matrix to test both Mongoid 5 and Mongoid 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ script: "bundle exec rspec spec"
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - 2.1.2
-  - jruby-19mode
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+gemfile:
+  - Gemfile
+  - gemfiles/mongoid-5.gemfile
 
 services:
   - mongodb

--- a/gemfiles/mongoid-5.gemfile
+++ b/gemfiles/mongoid-5.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gemspec path: "../"
+gem "mongoid", "~> 5.2"

--- a/mongoid-enum.gemspec
+++ b/mongoid-enum.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 5.0"
+  spec.add_runtime_dependency "mongoid", "> 5.0", "< 7.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec", "~> 4.6.2"
-  spec.add_development_dependency "mongoid-rspec", "~> 3.0"
+  spec.add_development_dependency "mongoid-rspec", "~> 4.0"
 end


### PR DESCRIPTION
Enhances the Travis build matrix to test multiple variations of Mongoid dependencies.

NOTE: This PR is stacked on top of PR #49 

/cc @thetron 

* Closes #46